### PR TITLE
Use screen's animation prop as default animation for .pop()

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ Router object can be found in route component parameters or can be got from `rou
 
 | Property | Type                                        | Description                                                       |
 | -------- | ------------------------------------------- | ----------------------------------------------------------------- |
-| pop      | function(animation)                         | Pops the last screen                                              |
+| pop      | function(optionalAnimation)                 | Pops the last screen                                              |
 | push     | object{key:function(parameters, animation)} | Object of functions to push new screen keyed by route name        |
 | replace  | object{key:function(parameters, animation)} | Object of functions to replace current screen keyed by route name |
 | reset    | object{key:function(parameters, animation)} | Object of functions to reset the whole stack keyed by route name  |
@@ -75,7 +75,7 @@ All functions return promises. Promise resolves when action finishes
 ```javascript
 // Example
 
-router.pop({type:'top'}).then(() => console.log('Popped')
+router.pop().then(() => console.log('Popped')
 router.push.First({value:123}, {type:'top'}).then(() => console.log('Pushed'))
 router.replace.Second({value:123}, {type:'top'}).then(() => console.log('Replaced'))
 router.reset.First({value:123}, {type:'top'}).then(() => console.log('Reset'))

--- a/src/methods.js
+++ b/src/methods.js
@@ -7,11 +7,10 @@ export default class Router {
 
     this.pop = animation =>
       router.actions.add(onFinish => {
-        if (router.state.stack.length === 0) return
-
-        router.state.stack[router.state.stack.length - 1].screen
-          .animateOut(animation)
-          .then(() => router.setState({ stack: router.state.stack.slice(0, -1) }, onFinish))
+        if (router.state.stack.length < 2) return
+        const { screen: lastScreen, props: { animation: lastAnimation } } = router.state.stack[router.state.stack.length - 1]
+        const onAnimationFinish = () => router.setState({ stack: router.state.stack.slice(0, -1) }, onFinish)
+        lastScreen.animateOut(animation || lastAnimation).then(onAnimationFinish)
       })
 
     this.push = forAllRoutes(route => (params, animation) =>

--- a/src/screenMethods.js
+++ b/src/screenMethods.js
@@ -8,9 +8,9 @@ export default class ScreenMethods {
     this.pop = animation =>
       router.actions.add(onFinish => {
         const removeLast = () => {
-          const lastScreen = router.state.stack[router.state.stack.length - 1].screen
+          const { screen: lastScreen, props: { animation: lastAnimation } } = router.state.stack[router.state.stack.length - 1]
           const onAnimationFinish = () => router.setState({ stack: router.state.stack.slice(0, -1) }, onFinish)
-          lastScreen.animateOut(animation).then(onAnimationFinish)
+          lastScreen.animateOut(animation || lastAnimation).then(onAnimationFinish)
         }
 
         const stack = [...router.state.stack.slice(0, index + 1), router.state.stack[router.state.stack.length - 1]]


### PR DESCRIPTION
Current operation is that `.pop()` needs to be passed an `animation`. This leads to 
- the client application needing to track how the screen was `push`ed, and 
- the Android back button always does the default `.pop()` animation

The new implementation will uses the `animation` prop from the last screen in the router stack, if no animation is supplied.

I have also made the `.pop()` code in `methods.js` match the code in `screenMethods.js` _(can these be made more DRY?)_

Additional bug fix: previous `.pop` in `methods.js` could work on a stack with length 1. New one does not:

```
 if (router.state.stack.length < 2) return
```