### PR TITLE
Add onBeforeStackChange and onStackChange props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,24 +28,37 @@ class Router extends React.Component {
       const last = this.state.stack[this.state.stack.length - 1]
       const stack = [...previous, { ...last, methods: { ...methods, id, route, params }, screen }]
 
-      this.setState({ stack }, () => screen.animateIn().then(onActionFinished))
+      this.setStack({ stack }, () => screen.animateIn().then(onActionFinished))
     }
     const screen = (
       <Screen animation={animation} animator={this.animator} key={id} ref={screenReferenceHandler}>
         <Route router={this.methods} {...params} />
       </Screen>
     )
-    this.setState({ stack: [...this.state.stack, screen] })
+    this.setStack({ stack: [...this.state.stack, screen] })
   }
 
-  componentWillMount = () => {
+  componentDidMount = () => {
+    this._isMounted = true
     this.addScreen(this.props.initialRoute, {}, { type: 'none' })
     this.hardware.subscribe()
 
     if (this.props.router) this.props.router(this.methods)
   }
 
-  componentWillUnmount = () => this.hardware.unsubscribe()
+  componentWillUnmount = () => {
+    this.hardware.unsubscribe()
+    this._isMounted = false
+  }
+
+  setStack = ({ stack }, onFinish) => {
+    if (this._isMounted) {
+      this.setState({ stack }, onFinish)
+      if (onFinish && this.props.onStackChange) {
+        this.props.onStackChange(stack.map(route => route.methods))
+      }
+    }
+  }
 
   render = () => <View style={styles.router}>{this.state.stack}</View>
 }

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,8 @@ class Router extends React.Component {
       const last = this.state.stack[this.state.stack.length - 1]
       const stack = [...previous, { ...last, methods: { ...methods, id, route, params }, screen }]
 
-      this.setStack({ stack }, () => screen.animateIn().then(onActionFinished))
+      this.setTransition(screen.props.animation, this.state.stack, stack)
+      screen.animateIn().then(() => { this.setStack({ stack }, onActionFinished, true) })
     }
     const screen = (
       <Screen animation={animation} animator={this.animator} key={id} ref={screenReferenceHandler}>
@@ -51,12 +52,18 @@ class Router extends React.Component {
     this._isMounted = false
   }
 
-  setStack = ({ stack }, onFinish) => {
+  setStack = ({ stack }, onFinish, toProps) => {
     if (this._isMounted) {
       this.setState({ stack }, onFinish)
-      if (onFinish && this.props.onStackChange) {
+      if (toProps && this.props.onStackChange) {
         this.props.onStackChange(stack.map(route => route.methods))
       }
+    }
+  }
+
+  setTransition = (animation, from, to) => {
+    if (this.props.onBeforeStackChange) {
+      this.props.onBeforeStackChange(animation, from.map(route => route.methods), to.map(route => route.methods))
     }
   }
 

--- a/src/methods.js
+++ b/src/methods.js
@@ -11,7 +11,7 @@ export default class Router {
 
         router.state.stack[router.state.stack.length - 1].screen
           .animateOut(animation)
-          .then(() => router.setState({ stack: router.state.stack.slice(0, -1) }, onFinish))
+          .then(() => router.setStack({ stack: router.state.stack.slice(0, -1) }, onFinish))
       })
 
     this.push = forAllRoutes(route => (params, animation) =>
@@ -21,7 +21,7 @@ export default class Router {
     this.replace = forAllRoutes(route => (params, animation) =>
       router.actions.add(onFinish => {
         const removeReplacedScreen = () =>
-          router.setState(
+          router.setStack(
             { stack: [...router.state.stack.slice(0, -2), router.state.stack[router.state.stack.length - 1]] },
             onFinish
           )
@@ -32,7 +32,7 @@ export default class Router {
     this.reset = forAllRoutes(route => (params, animation) =>
       router.actions.add(onFinish => {
         const removeAllScreens = () =>
-          router.setState({ stack: [router.state.stack[router.state.stack.length - 1]] }, onFinish)
+          router.setStack({ stack: [router.state.stack[router.state.stack.length - 1]] }, onFinish)
         router.addScreen(route, params, animation, removeAllScreens, router.state.stack.length)
       })
     )

--- a/src/methods.js
+++ b/src/methods.js
@@ -9,9 +9,12 @@ export default class Router {
       router.actions.add(onFinish => {
         if (router.state.stack.length === 0) return
 
-        router.state.stack[router.state.stack.length - 1].screen
+        const newStack = router.state.stack.slice(0, -1)
+        const { screen } = router.state.stack[router.state.stack.length - 1]
+        router.setTransition(animation || screen.props.animation, router.state.stack, newStack)
+        screen
           .animateOut(animation)
-          .then(() => router.setStack({ stack: router.state.stack.slice(0, -1) }, onFinish))
+          .then(() => router.setStack({ stack: newStack }, onFinish, true))
       })
 
     this.push = forAllRoutes(route => (params, animation) =>
@@ -23,7 +26,8 @@ export default class Router {
         const removeReplacedScreen = () =>
           router.setStack(
             { stack: [...router.state.stack.slice(0, -2), router.state.stack[router.state.stack.length - 1]] },
-            onFinish
+            onFinish,
+            true
           )
         router.addScreen(route, params, animation, removeReplacedScreen, 1)
       })
@@ -32,7 +36,7 @@ export default class Router {
     this.reset = forAllRoutes(route => (params, animation) =>
       router.actions.add(onFinish => {
         const removeAllScreens = () =>
-          router.setStack({ stack: [router.state.stack[router.state.stack.length - 1]] }, onFinish)
+          router.setStack({ stack: [router.state.stack[router.state.stack.length - 1]] }, onFinish, true)
         router.addScreen(route, params, animation, removeAllScreens, router.state.stack.length)
       })
     )

--- a/src/screenMethods.js
+++ b/src/screenMethods.js
@@ -9,19 +9,21 @@ export default class ScreenMethods {
       router.actions.add(onFinish => {
         const removeLast = () => {
           const lastScreen = router.state.stack[router.state.stack.length - 1].screen
-          const onAnimationFinish = () => router.setStack({ stack: router.state.stack.slice(0, -1) }, onFinish)
+          const onAnimationFinish = () => router.setStack({ stack: newStack }, onFinish, true)
+          const newStack = router.state.stack.slice(0, -1)
+          router.setTransition(animation || lastScreen.props.animation, router.state.stack, newStack)
           lastScreen.animateOut(animation).then(onAnimationFinish)
         }
 
         const stack = [...router.state.stack.slice(0, index + 1), router.state.stack[router.state.stack.length - 1]]
-        router.setStack({ stack }, removeLast)
+        router.setStack({ stack }, removeLast, true)
       })
 
     this.replace = forAllRoutes(route => (params, animation) =>
       router.actions.add(onFinish => {
         const onAdd = () => {
           const stack = [...router.state.stack.slice(0, index), router.state.stack[router.state.stack.length - 1]]
-          router.setStack({ stack }, onFinish)
+          router.setStack({ stack }, onFinish, true)
         }
         router.addScreen(route, params, animation, onAdd, router.state.stack.length - index)
       })

--- a/src/screenMethods.js
+++ b/src/screenMethods.js
@@ -9,19 +9,19 @@ export default class ScreenMethods {
       router.actions.add(onFinish => {
         const removeLast = () => {
           const lastScreen = router.state.stack[router.state.stack.length - 1].screen
-          const onAnimationFinish = () => router.setState({ stack: router.state.stack.slice(0, -1) }, onFinish)
+          const onAnimationFinish = () => router.setStack({ stack: router.state.stack.slice(0, -1) }, onFinish)
           lastScreen.animateOut(animation).then(onAnimationFinish)
         }
 
         const stack = [...router.state.stack.slice(0, index + 1), router.state.stack[router.state.stack.length - 1]]
-        router.setState({ stack }, removeLast)
+        router.setStack({ stack }, removeLast)
       })
 
     this.replace = forAllRoutes(route => (params, animation) =>
       router.actions.add(onFinish => {
         const onAdd = () => {
           const stack = [...router.state.stack.slice(0, index), router.state.stack[router.state.stack.length - 1]]
-          router.setState({ stack }, onFinish)
+          router.setStack({ stack }, onFinish)
         }
         router.addScreen(route, params, animation, onAdd, router.state.stack.length - index)
       })


### PR DESCRIPTION
Adds support for two optional props on the router:
```
onBeforeStackChange = function (animation: Animation, from: Array<Route>, to: Array<Route>)
onStackChange = function (stack: Array<Route>)
```

Also closes #9 