### PR TITLE
Use incrementing counter instead of Math.random() for id

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,8 @@ import ScreenMethods from './screenMethods'
 import styles from './styles'
 import { View } from 'react-native'
 
+let counter = 0
+
 class Router extends React.Component {
   actions = new Actions()
   animator = new Animator(this.props.animations)
@@ -18,7 +20,8 @@ class Router extends React.Component {
 
   addScreen = (route, params, animation, onActionFinished, idShift = 0) => {
     const index = this.state.stack.length - idShift
-    const id = `${index}-${route}-${parseInt(Math.random() * 10000)}`
+    const id = `${index}-${route}-${counter}`
+    counter += 1
     const Route = this.props.routes[route]
     const screenReferenceHandler = screen => {
       if (!screen) return


### PR DESCRIPTION
As `index` and `route` could be reused, this line:

https://github.com/sergeyshpadyrev/react-native-easy-router/blob/78b45aebfedf42aabb440ee7a30dfe08b73ad3bd/src/index.js#L21

_could_ produce a duplicate `id` (unlikely, I know, but possible....)

This commit uses an `id` counter that never gets reset, so will never have a duplicate