### PR TITLE
Only handle Android back button if performing pop()

### DIFF
--- a/src/hardware.js
+++ b/src/hardware.js
@@ -7,8 +7,11 @@ export default class HardwareBack {
   }
 
   handle = () => {
-    if (this.methods.stack.length > 1) this.methods.pop()
-    return true
+    if (this.methods.stack.length > 1) {
+      this.methods.pop()
+      return true
+    }
+    return false
   }
 
   subscribe = () => {


### PR DESCRIPTION
Current behaviour if `disableHardwareBack=true` is to suppress the default Android back functionality (exit the app), and also to `pop()` if there is anything on the stack

This PR changes the behaviour to only suppress the default Android back functionality if the router is doing a `pop()`. This is more in keeping with the functionality of other apps

An app could still choose suppress the functionality completely by adding its own `hardwareBackPress` listener that returns `true`