### PR TITLE
Allow custom styling (fix issue #24)

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -86,6 +86,7 @@ declare module "react-native-easy-router" {
         };
         initialRoute: string;
         router?: (router: Router) => void;
+        style?: ViewStyle;
         disableHardwareBack?: boolean;
         onStackChange?: (stack: RouterStack) => void;
         onBeforeStackChange?: (animation: Animation, fromStack: RouterStack, toStack: RouterStack) => void;

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,7 @@ class Router extends React.Component {
     )
   }
 
-  render = () => <View style={styles.router}>{this.state.stack}</View>
+  render = () => <View pointerEvents="box-none" style={{...this.props.style, ...styles.router}}>{this.state.stack}</View>
 }
 
 export default Router

--- a/src/screen.js
+++ b/src/screen.js
@@ -40,7 +40,7 @@ export default class Screen extends React.Component {
     const style = { ...styles.screen, ...this.props.animator.start(type) }
     const useNativeDriver = this.props.animator.useNativeDriver(type)
     return (
-      <Animatable.View style={style} ref={view => (this.view = view)} useNativeDriver={useNativeDriver}>
+      <Animatable.View pointerEvents="box-none" style={style} ref={view => (this.view = view)} useNativeDriver={useNativeDriver}>
         {this.props.children}
       </Animatable.View>
     )


### PR DESCRIPTION
This change allows clients to add custom styling to the router (or rather the View it creates). It also ensures that both the View and the Animatable.View are set to pointerEvents="box-none". This ensures you can create views inside the router that are transparent and allow touch events to be passed through