### PR TITLE
Use shorthand for react-native-swipe-gestures to allow for ssh installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "types": "src/index.d.ts",
   "dependencies": {
     "react-native-animatable-promise": "^1.2.4",
-    "react-native-swipe-gestures": "git://github.com/thegamenicorus/react-native-swipe-gestures.git"
+    "react-native-swipe-gestures": "thegamenicorus/react-native-swipe-gestures.git"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hello

The place I'm currently contracting at rejects all non-SSH git addresses, so I couldn't install easy-router, until I made swipe gestures use a relative link, like this