### PR TITLE
Add new parameters for applying a separate transition animation to the bottom screen

### DIFF
--- a/example/09_custom_animation/index.js
+++ b/example/09_custom_animation/index.js
@@ -22,7 +22,13 @@ const Screen = ({ children, color }) => (
 
 const { width, height } = Dimensions.get('window')
 const animations = {
-  'skew-fade': [{ transform: [{ skewX: '90deg' }], opacity: 0 }, { transform: [{ skewX: '0deg' }], opacity: 1 }, false]
+  'skew-fade': [
+    { transform: [{ skewX: '90deg' }], opacity: 0 },
+    { transform: [{ skewX: '0deg' }], opacity: 1 },
+    false,
+    { transform: [{ translateX: -width / 3 }], opacity: 0 },
+    { transform: [{ translateX: 0 }], opacity: 1 },
+  ]
 }
 
 const Screen1 = ({ router }) => (

--- a/readme.md
+++ b/readme.md
@@ -146,6 +146,8 @@ Also you can pass your custom animation types to router. Where type is array con
 | 0     | Object  | Start position for in animation / end position for out animation |
 | 1     | Object  | Start position for out animation / end position for in animation |
 | 2     | Boolean | Usage of native driver animation                                 |
+| 3     | Object  | (optional) End position for out animation of previous screen     |
+| 4     | Object  | (optional) End position for in animation of previous screen      |
 
 ```javascript
 // Example

--- a/src/animation.js
+++ b/src/animation.js
@@ -44,6 +44,8 @@ export default class Animator {
   start = this.getTypeProperty(0)
   end = this.getTypeProperty(1)
   useNativeDriver = this.getTypeProperty(2)
+  prevOut = this.getTypeProperty(3)
+  prevIn = this.getTypeProperty(4)
   shouldFade = type => {
     const { opacity, transform } = this.types[type][0]
     return opacity === undefined || transform !== undefined

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -48,7 +48,10 @@ declare module "react-native-easy-router" {
 
     export type AnimationPosition = ViewStyle;
 
-    export type CustomAnimation = [AnimationPosition, AnimationPosition, boolean];
+    export type CustomAnimation =
+      | [AnimationPosition, AnimationPosition, boolean]
+      | [AnimationPosition, AnimationPosition, boolean, AnimationPosition]
+      | [AnimationPosition, AnimationPosition, boolean, AnimationPosition, AnimationPosition];
 
     export interface CustomAnimations {
         [animation: string]: CustomAnimation;

--- a/src/screen.js
+++ b/src/screen.js
@@ -15,7 +15,7 @@ export default class Screen extends React.Component {
     if (type === 'none') return Promise.resolve()
     const transition = this.view.transitionTo(this.props.animator.end(type), duration, easing)
     if (!this.props.animator.shouldFade(type)) return transition
-    return Promise.all(transitions(transition, screen => screen.fadeOut(duration, easing), stack))
+    return Promise.all(transitions(transition, screen => screen.fadeOut(duration, easing, type), stack))
   }
 
   animateOut = (animation, stack) => {
@@ -29,12 +29,12 @@ export default class Screen extends React.Component {
     }
     const transition = this.view.transitionTo(this.props.animator.start(type), duration, easing)
     if (!this.props.animator.shouldFade(type)) return transition
-    return Promise.all(transitions(transition, screen => screen.fadeIn(duration, easing), stack))
+    return Promise.all(transitions(transition, screen => screen.fadeIn(duration, easing, type), stack))
   }
 
-  fadeIn = (duration, easing) => this.view.transitionTo(this.props.animator.end('fade'), duration, easing)
+  fadeIn = (duration, easing, type) => this.view.transitionTo(this.props.animator.prevIn(type) || this.props.animator.end('fade'), duration, easing)
 
-  fadeOut = (duration, easing) => this.view.transitionTo(this.props.animator.start('fade'), duration, easing)
+  fadeOut = (duration, easing, type) => this.view.transitionTo(this.props.animator.prevOut(type) || this.props.animator.start('fade'), duration, easing)
 
   transparent = () => this.view.transitionTo({ opacity: 0 }, 0)
 


### PR DESCRIPTION
This commit builds on the animation API to allow animation of the previous screen. As such, it may close #27 

It adds 2 optional extra parameters to the custom animtions arrays. This means that this:
```typescript
const animations: CustomAnimations = {
  fadeRight: [

    // top screen start position
    { transform: [{ translateX: width }], opacity: 0 }, 

    // top screen end position
    { transform: [{ translateX: 0 }], opacity: 1 },

    // native driver
    false,

    // bottom screen end position when push()ed over
    { transform: [{ translateX: -width / 3 }], opacity: 0 },

    // bottom screen end position when pop()ped back
    { transform: [{ translateX: 0 }], opacity: 1 },

  ],
};
```
will fade in the top screen from the right, and will also move the bottom screen left 1/3 of the screen while fading it out (and back when popped)

@jliebrand - can you see if this helps your use case?